### PR TITLE
Update heroku-start script to check for HTTP and redirect to HTTPS

### DIFF
--- a/scripts/heroku-start.js
+++ b/scripts/heroku-start.js
@@ -1,23 +1,29 @@
-const express = require('express'); 
-const path = require('path');
+const express = require("express");
+const path = require("path");
 const app = express();
 const port = process.env.PORT || 3000;
+
+// Check if request is from HTTP and if so, redirect to HTTPS
+app.enable("trust proxy");
+app.use((req, res, next) => {
+  req.secure ? next() : res.redirect("https://" + req.headers.host + req.url);
+});
 
 app.use(express.json());
 
 // Your static site folder name
-app.use(express.static(path.join(__dirname, '..', 'build')));
+app.use(express.static(path.join(__dirname, "..", "build")));
 
 // Root Redirects to the build in assets folder
-app.get('/', function(req,res){
-  res.sendFile(path.join(__dirname, '..', 'build'));
+app.get("/", function (req, res) {
+  res.sendFile(path.join(__dirname, "..", "build"));
 });
 
 // Any Page Redirects to the build in assets folder index.html that will load the react app
-app.get('*', function(req,res){
-  res.sendFile(path.join(__dirname, '..', 'build/index.html'));
+app.get("*", function (req, res) {
+  res.sendFile(path.join(__dirname, "..", "build/index.html"));
 });
 
-app.listen(port, ()=>{
-    console.log("Server is running on port: ", port)
-})
+app.listen(port, () => {
+  console.log("Server is running on port: ", port);
+});


### PR DESCRIPTION
Thanks for your excellent script @velles!

I have just added a logic to check if the request is coming from HTTP and if so, redirect to HTTPS which I found here: https://stackoverflow.com/a/49176816

I have tested this here: http://clickit-admin-qa.herokuapp.com

Can you please add this so that others can also benefit?

I do not think anyone will want to run on HTTP on heroku.